### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/FICS/gamedb.c
+++ b/FICS/gamedb.c
@@ -1624,6 +1624,12 @@ OldestHistGame(char *login)
 	char		 pFile[MAX_FILENAME_SIZE] = { '\0' };
 	long int	 when;
 
+	/* Validate login to prevent path traversal */
+	if (strstr(login, "..") || strchr(login, '/') || strchr(login, '\\')) {
+		warnx("%s: invalid login value: '%s'", __func__, login);
+		return 0L;
+	}
+
 	msnprintf(pFile, sizeof pFile, "%s/player_data/%c/%s.%s", stats_dir,
 	    login[0], login, STATS_GAMES);
 


### PR DESCRIPTION
Potential fix for [https://github.com/uhlin/fics/security/code-scanning/6](https://github.com/uhlin/fics/security/code-scanning/6)

To fix the problem, we need to validate the `login` value before using it to construct a file path. Since `login` is used as a filename component, we should ensure it does not contain any path separators (`/` or `\`) or sequences like `..` that could allow path traversal. The best way is to add a check in the `OldestHistGame` function to reject any `login` value containing these characters or sequences. If the validation fails, the function should return early (e.g., return `0L`), and optionally log a warning.

**Required changes:**
- In `OldestHistGame`, before constructing the file path, check that `login` does not contain `/`, `\`, or `..`.
- If invalid, log a warning and return `0L`.
- No new imports are needed, as we can use `strstr` and `strchr` from `<string.h>`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
