### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/FICS/makerank.c
+++ b/FICS/makerank.c
@@ -184,6 +184,12 @@ LoadEntries(void)
 
 			e.name[strcspn(e.name, "\n")] = '\0';
 
+			/* Validate that e.name does not contain path traversal or separators */
+			if (strstr(e.name, "..") || strchr(e.name, '/') || strchr(e.name, '\\')) {
+				printf("Skipping invalid filename: %s\n", e.name);
+				continue;
+			}
+
 			if (e.name[0] != letter1) {
 				printf("File %c/%s: wrong directory.\n",
 				    letter1, e.name);


### PR DESCRIPTION
Potential fix for [https://github.com/uhlin/fics/security/code-scanning/7](https://github.com/uhlin/fics/security/code-scanning/7)

To fix the problem, we need to validate the filenames read from the directory before using them to construct file paths. Since the filenames are used as a single path component (i.e., as a filename, not a path), we should ensure that they do not contain any path separators (`/` or `\`) or the sequence `..`. This can be done by checking for these characters/sequences in `e.name` after reading it from `fgets` and before using it in `snprintf` to build `pathInput`. If any invalid characters or sequences are found, the filename should be skipped, and a warning can be printed.

The changes should be made in `FICS/makerank.c`, specifically in the loop where filenames are read and processed (lines 181–193). We will add a validation step after line 185 (after stripping the newline) and before using `e.name` to construct the path. If the filename is invalid, we skip to the next iteration.

No new imports are needed, as we can use `strstr`, `strchr`, and standard C functions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
