### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/FICS/gamedb.c
+++ b/FICS/gamedb.c
@@ -1724,6 +1724,12 @@ RemHist(char *who)
 			}
 
 			stolower(Opp);
+			/* Validate Opp before using it as a login */
+			if (strstr(Opp, "..") || strchr(Opp, '/') || strchr(Opp, '\\')) {
+				warnx("%s: invalid Opp value: '%s' (skipping)", __func__, Opp);
+				iter_no++;
+				continue;
+			}
 			oppWhen = OldestHistGame(Opp);
 
 			if (oppWhen > When || oppWhen <= 0L) {


### PR DESCRIPTION
Potential fix for [https://github.com/uhlin/fics/security/code-scanning/5](https://github.com/uhlin/fics/security/code-scanning/5)

To fix the problem, we need to ensure that the value of `Opp` (used as `login` in `OldestHistGame`) is validated before it is used to construct a file path. While `OldestHistGame` already performs a check for path traversal and separator characters, it is best practice to validate the input as soon as it is read, and to ensure that the validation is robust and consistently applied. In this case, we should validate `Opp` immediately after reading it from the file (in the loop at line 1719), before passing it to `OldestHistGame`. This can be done by checking for the presence of `..`, `/`, or `\` in `Opp`, and skipping any iteration where `Opp` is invalid. This prevents any tainted value from reaching the file access function.

**Required changes:**
- In the loop where `Opp` is read (lines 1717-1741), add a validation check for `Opp` after it is read and before it is used.
- If `Opp` is invalid, log a warning and skip the iteration.
- No new imports are needed, as the required functions (`strstr`, `strchr`, `warnx`) are already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
