### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/FICS/gamedb.c
+++ b/FICS/gamedb.c
@@ -1730,7 +1730,17 @@ RemHist(char *who)
 				iter_no++;
 				continue;
 			}
+			/* Additional validation: only allow alphanumeric and underscores */
+			for (char *p = Opp; *p; ++p) {
+				if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+				      (*p >= '0' && *p <= '9') || *p == '_')) {
+					warnx("%s: Opp contains invalid character: '%s' (skipping)", __func__, Opp);
+					iter_no++;
+					goto next_iter;
+				}
+			}
 			oppWhen = OldestHistGame(Opp);
+		next_iter:;
 
 			if (oppWhen > When || oppWhen <= 0L) {
 				char histfile[MAX_FILENAME_SIZE] = { '\0' };


### PR DESCRIPTION
Potential fix for [https://github.com/uhlin/fics/security/code-scanning/5](https://github.com/uhlin/fics/security/code-scanning/5)

To fix the problem, we should ensure that any value used to construct a file path is strictly validated before use. The current validation in `OldestHistGame` is good, but we can strengthen it by also validating `Opp` immediately after it is read from the file (in the loop at line 1728), before passing it to `OldestHistGame`. This ensures that no invalid value is ever used as a login, and that the validation is performed as close to the source as possible. Additionally, we should consider using an allow-list for valid login names (e.g., only alphanumeric characters and underscores), but for now, we will enhance the existing check.

**Required changes:**
- In the loop where `Opp` is read (lines 1717–1747), add a stricter validation for `Opp` before calling `OldestHistGame`.
- Optionally, refactor the validation logic into a helper function for clarity and reuse.
- No new imports are needed, as we can use standard C library functions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
